### PR TITLE
Levels separation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,6 @@ module.exports = {
     'firecloud/node.js'
   ],
   env: {
-    "jest": true
+    jest: true
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,8 @@ module.exports = {
   root: true,
   extends: [
     'firecloud/node.js'
-  ]
+  ],
+  env: {
+    "jest": true
+  }
 };

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "eslint-plugin-max-len-2": "0.0.5",
     "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-no-null": "1.0.2",
+    "jest": "21.1.0",
     "npm-publish-git": "git://github.com/andreineculau/npm-publish-git.git#v0.0.3"
   },
   "scripts": {
-    "prepare": "make package-json-prepare"
+    "prepare": "make package-json-prepare",
+    "test": "jest"
   }
 }

--- a/src/levels.js
+++ b/src/levels.js
@@ -1,0 +1,69 @@
+import _ from 'lodash';
+
+export let levels = {
+  // https://tools.ietf.org/html/rfc3164 (multiplier 10)
+  emergency: 0,
+  alert: 10,
+  critical: 20,
+  error: 30,
+  warning: 40,
+  notice: 50,
+  informational: 60,
+  debug: 70,
+
+  // console
+  warn: 40, // warning
+  info: 60, // informational
+  trace: 90,
+
+  // alias
+  fatal: 0, // emergency
+  verbose: 70, // debug
+  silly: 80,
+
+
+  levelToLevelName: function(level) {
+    if (_.isString(level)) {
+      // eslint-disable-next-line prefer-destructuring
+      level = this[level] || this.trace;
+    }
+
+    let levelName = _.invert(this)[level] || `lvl${level}`;
+    switch (levelName) {
+    case 'verbose':
+      levelName = 'debug';
+      break;
+    default:
+      break;
+    }
+
+    return levelName;
+  },
+
+
+  levelToConsoleFun: function(level) {
+    if (_.isString(level)) {
+      // eslint-disable-next-line prefer-destructuring
+      level = this[level];
+    }
+
+    if (_.inRange(level, 0, this.warn)) {
+      return 'error';
+    } else if (_.inRange(level, this.warn, this.info)) {
+      return 'warn';
+    } else if (_.inRange(level, this.info, this.debug)) {
+      return 'info';
+    } else if (_.inRange(level, this.debug, this.trace)) {
+      // return 'debug';
+      // console.debug doesn't seem to print anything,
+      // but console.debug is an alias to console.log anyway
+      return 'log';
+    } else if (level === this.trace) {
+      return 'trace';
+    }
+
+    return 'log';
+  }
+};
+
+export default levels;

--- a/src/listeners/log-to-console.js
+++ b/src/listeners/log-to-console.js
@@ -4,7 +4,7 @@ import moment from 'moment';
 /*
 cfg has 2 properties
 - level (optional, defaults to trace)
-  Any log entry less important that cfg.level is ignore.
+  Any log entry less important that cfg.level is ignored.
 - iframeId (optional, default to 'top' or '?'
   An identifier for the current "window".
 */
@@ -23,9 +23,9 @@ export default function(cfg = {}) {
     }
 
     let now = moment(entry._time.stamp).utcOffset(entry._time.utc_offset).toISOString();
-    let levelName = logger.levelToLevelName(entry._level);
+    let levelName = logger.levels.levelToLevelName(entry._level);
     let formattedLevelName = _.padStart(_.toUpper(levelName), '5');
-    let consoleFun = logger.levelToConsoleFun(entry._level);
+    let consoleFun = logger.levels.levelToConsoleFun(entry._level);
 
     let color = '';
     switch (consoleFun) {

--- a/src/minlog.js
+++ b/src/minlog.js
@@ -1,39 +1,5 @@
 import _ from 'lodash';
-
-// See http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
-export let _getCallerInfo = function(level) {
-  // eslint-disable-next-line no-invalid-this, consistent-this
-  let self = this;
-
-  // 'strict' mode has no caller info
-  if (self === undefined) {
-    return;
-  }
-
-  let origLimit = Error.stackTraceLimit;
-  let origPrepare = Error.prepareStackTrace;
-  Error.stackTraceLimit = level;
-
-  let info;
-  Error.prepareStackTrace = function(_err, stack) {
-    let caller = stack[level - 1];
-    if (_.isUndefined(caller)) {
-      return;
-    }
-
-    info = {
-      file: caller.getFileName(),
-      line: caller.getLineNumber(),
-      function: caller.getFunctionName()
-    };
-  };
-  // eslint-disable-next-line no-unused-expressions
-  Error().stack;
-
-  Error.stackTraceLimit = origLimit;
-  Error.prepareStackTrace = origPrepare;
-  return info;
-};
+import {getCallerInfo} from './util';
 
 export default class MinLog {
   levels = {
@@ -123,7 +89,7 @@ export default class MinLog {
       level = this.levels[level];
     }
 
-    let src = exports._getCallerInfo(5);
+    let src = getCallerInfo(5);
 
     let entry = {
       _time: new Date(),

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,38 @@
+import _ from 'lodash';
+
+// See http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+export let getCallerInfo = function(level) {
+  // eslint-disable-next-line no-invalid-this, consistent-this
+  let self = this;
+
+  // 'strict' mode has no caller info
+  if (self === undefined) {
+    return;
+  }
+
+  let origLimit = Error.stackTraceLimit;
+  let origPrepare = Error.prepareStackTrace;
+  Error.stackTraceLimit = level;
+
+  let info;
+  Error.prepareStackTrace = function(_err, stack) {
+    let caller = stack[level - 1];
+    if (_.isUndefined(caller)) {
+      return;
+    }
+
+    info = {
+      file: caller.getFileName(),
+      line: caller.getLineNumber(),
+      function: caller.getFunctionName()
+    };
+  };
+  // eslint-disable-next-line no-unused-expressions
+  Error().stack;
+
+  Error.stackTraceLimit = origLimit;
+  Error.prepareStackTrace = origPrepare;
+  return info;
+};
+
+export default exports;

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -1,0 +1,92 @@
+import _ from 'lodash';
+import levels from '../src/levels';
+
+describe('levels', () => {
+  it('should be defined', () => {
+    let expectedLevels = [
+      'alert',
+      'critical',
+      'debug',
+      'emergency',
+      'error',
+      'fatal',
+      'info',
+      'informational',
+      'notice',
+      'silly',
+      'trace',
+      'verbose',
+      'warn',
+      'warning'];
+
+    _.forEach(expectedLevels, (lvl) => {
+      expect(levels[lvl]).toBeDefined();
+    });
+  });
+});
+
+describe('levelToLevelName', () => {
+  it('should be defined', () => {
+    expect(levels.levelToLevelName).not.toBeUndefined();
+  });
+
+  it('should return as expected for defined levels', () => {
+    expect(levels.levelToLevelName(levels.alert)).toBe('alert');
+    expect(levels.levelToLevelName(levels.critical)).toBe('critical');
+    expect(levels.levelToLevelName(levels.debug)).toBe('debug');
+    expect(levels.levelToLevelName(levels.emergency)).toBe('fatal');
+    expect(levels.levelToLevelName(levels.error)).toBe('error');
+    expect(levels.levelToLevelName(levels.fatal)).toBe('fatal');
+    expect(levels.levelToLevelName(levels.info)).toBe('info');
+    expect(levels.levelToLevelName(levels.informational)).toBe('info');
+    expect(levels.levelToLevelName(levels.notice)).toBe('notice');
+    expect(levels.levelToLevelName(levels.silly)).toBe('silly');
+    expect(levels.levelToLevelName(levels.trace)).toBe('trace');
+    expect(levels.levelToLevelName(levels.verbose)).toBe('debug');
+    expect(levels.levelToLevelName(levels.warn)).toBe('warn');
+    expect(levels.levelToLevelName(levels.warning)).toBe('warn');
+  });
+
+  it('should return as expected for custom levels', () => {
+    expect(levels.levelToLevelName(42)).toBe('lvl42');
+  });
+});
+
+describe('levelToConsoleFun', () => {
+  it('should be defined', () => {
+    expect(levels.levelToConsoleFun).not.toBeUndefined();
+  });
+
+  it('should return as expected for defined levels', () => {
+    expect(levels.levelToConsoleFun(levels.alert)).toBe('error');
+    expect(levels.levelToConsoleFun(levels.critical)).toBe('error');
+    expect(levels.levelToConsoleFun(levels.debug)).toBe('log');
+    expect(levels.levelToConsoleFun(levels.emergency)).toBe('error');
+    expect(levels.levelToConsoleFun(levels.error)).toBe('error');
+    expect(levels.levelToConsoleFun(levels.fatal)).toBe('error');
+    expect(levels.levelToConsoleFun(levels.info)).toBe('info');
+    expect(levels.levelToConsoleFun(levels.informational)).toBe('info');
+    expect(levels.levelToConsoleFun(levels.notice)).toBe('warn');
+    expect(levels.levelToConsoleFun(levels.silly)).toBe('log');
+    expect(levels.levelToConsoleFun(levels.trace)).toBe('trace');
+    expect(levels.levelToConsoleFun(levels.verbose)).toBe('log');
+    expect(levels.levelToConsoleFun(levels.warn)).toBe('warn');
+    expect(levels.levelToConsoleFun(levels.warning)).toBe('warn');
+  });
+
+  it('should pick up string names of levels', () => {
+    expect(levels.levelToConsoleFun('verbose')).toBe('log');
+  });
+
+  it('should return correctly for intermediate levels', () => {
+    expect(levels.levelToConsoleFun((levels.error + levels.warn) / 2)).toBe('error');
+  });
+
+  it('should return log as default', () => {
+    expect(levels.levelToConsoleFun()).toBe('log');
+    expect(levels.levelToConsoleFun({})).toBe('log');
+    expect(levels.levelToConsoleFun('blabla')).toBe('log');
+    expect(levels.levelToConsoleFun('levelToConsoleFun')).toBe('log');
+  });
+});
+

--- a/test/minlog.test.js
+++ b/test/minlog.test.js
@@ -1,0 +1,42 @@
+import _ from 'lodash';
+import MinLog from '../src/minlog';
+import defaultLevels from '../src/levels';
+
+describe('MinLog', () => {
+  it('should be defined', () => {
+    expect(MinLog).toBeDefined();
+  });
+
+
+  it('should have default log levels funcs', () => {
+    let instance = new MinLog();
+
+    _.forEach(defaultLevels, (level, levelName) => {
+      if (_.isNumber(level)) {
+        expect(instance).toHaveProperty(levelName);
+      }
+    });
+  });
+
+
+  it('should have non-default log levels funcs when supplied', () => {
+    let customLevels = {
+      foo: 0,
+      bar: 10,
+      baz: 20
+    };
+
+    let instance = new MinLog({levels: customLevels});
+
+    _.forEach(customLevels, (_level, levelName) => {
+      expect(instance).toHaveProperty(levelName);
+    });
+  });
+
+
+  it('should have levels clone in a property', () => {
+    let instance = new MinLog();
+
+    expect(_.isEqual(instance.levels, defaultLevels)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
It all started with `levelToConsoleFun` moving out... But it didn't feel right to split it with `levelToLevelName`, so it became a separate thing.

But now custom levels can be provided in the constructor of `MinLog` and if the "interface" with `levelToLevelName` and `levelToConoleFun` is implemented, default console listener will work.