### PR TITLE
add levelToLevelCode

### DIFF
--- a/src/listeners/log-to-console.js
+++ b/src/listeners/log-to-console.js
@@ -53,10 +53,9 @@ export let logToConsole = function(cfg = {}) {
       return;
     }
 
-    let maxLevelName = cfg.level;
-    let maxLevel = logger.levels[maxLevelName];
-    maxLevel = _.floor(maxLevel / 10) * 10 + 10 - 1; // round up to next level, not inclusive
-    if (entry._level > maxLevel) {
+    let maxLevelCode = logger.levelToLevelCode(cfg.level);
+    maxLevelCode = _.floor(maxLevelCode / 10) * 10 + 10 - 1; // round up to next level, not inclusive
+    if (entry._level > maxLevelCode) {
       return;
     }
 

--- a/src/minlog.js
+++ b/src/minlog.js
@@ -45,6 +45,26 @@ export default class MinLog {
     });
   }
 
+  levelToLevelCode(levelCodeOrName) {
+    if (_.isInteger(levelCodeOrName)) {
+      let levelCode = levelCodeOrName;
+      return levelCode;
+    }
+
+    let levelName = levelCodeOrName;
+    if (/^lvl[0-9]+$/.test(levelName)) {
+      let levelCode = _.replace(levelName, /^lvl/, '');
+      levelCode = _.toInteger(levelCode);
+      return levelCode;
+    }
+
+    if (_.isUndefined(this.levels[levelName])) {
+      throw new Error(`Unknown level name ${levelName}. Known: ${_.keys(this.levels)}.`);
+    }
+
+    return this.levels[levelName];
+  }
+
   levelToLevelName(levelCodeOrName) {
     if (_.isString(levelCodeOrName)) {
       let levelName = levelCodeOrName;

--- a/test/minlog.test.js
+++ b/test/minlog.test.js
@@ -33,6 +33,40 @@ describe('minlog', function() {
     });
   });
 
+  describe('levelToLevelCode', function() {
+    let instance = new MinLog();
+
+    it('should return the level code for defined level names', function() {
+      _.forEach(_.keys(instance.levels), function(levelName) {
+        let levelCode = instance.levelToLevelCode(levelName);
+
+        expect(levelCode).toBe(instance.levels[levelName]);
+      });
+    });
+
+    it('should return the level code for defined level codes', function() {
+      _.forEach(_.values(instance.levels), function(vanillaLevelCode) {
+        let levelCode = instance.levelToLevelCode(vanillaLevelCode);
+
+        expect(levelCode).toBe(vanillaLevelCode);
+      });
+    });
+
+    it('should return the level code for undefined <lvlN> levels', function() {
+      _.forEach(_.range(0, 100), function(vanillaLevelCode) {
+        let levelName = instance.levelToLevelName(vanillaLevelCode);
+
+        if (levelName in instance.levels) {
+          // ignore defined levels
+          return;
+        }
+
+        let levelCode = instance.levelToLevelCode(levelName);
+        expect(levelCode).toBe(vanillaLevelCode);
+      });
+    });
+  });
+
   describe('levelToLevelName', function() {
     let instance = new MinLog();
 


### PR DESCRIPTION
~~EDIT: also adding a `levelToLevelCode` function (needed in aws-util-firecloud)~~

(pushed the no-brainer "naming" diffs to master)