### PR TITLE
add convenience functions

### DIFF
--- a/src/listeners/log-to-console.js
+++ b/src/listeners/log-to-console.js
@@ -59,8 +59,7 @@ export let logToConsole = function(cfg = {}) {
       return;
     }
 
-    let maxLevelCode = logger.levelToLevelCode(cfg.level);
-    maxLevelCode = _.floor(maxLevelCode / 10) * 10 + 10 - 1; // round up to next level, not inclusive
+    let maxLevelCode = logger.maxLevelCodeInGroup(cfg.level);
     if (entry._level > maxLevelCode) {
       return;
     }

--- a/src/listeners/log-to-console.js
+++ b/src/listeners/log-to-console.js
@@ -59,8 +59,7 @@ export let logToConsole = function(cfg = {}) {
       return;
     }
 
-    let maxLevelCode = logger.maxLevelCodeInGroup(cfg.level);
-    if (entry._level > maxLevelCode) {
+    if (logger.levelIsBeyondGroup(entry._level, cfg.level)) {
       return;
     }
 

--- a/src/minlog.js
+++ b/src/minlog.js
@@ -83,6 +83,15 @@ export default class MinLog {
     return levelName;
   }
 
+  maxLevelCodeInGroup(levelCodeOrName) {
+    let levelCode = this.levelToLevelCode(levelCodeOrName);
+
+    // round up levelCode to next level group, not inclusive
+    let maxLevelCodeGroup = _.floor(levelCode / 10) + 1;
+    let maxLevelCode = maxLevelCodeGroup * 10 - 1;
+    return maxLevelCode;
+  }
+
   async log(levelCodeOrName, ...args) {
     let levelCode = levelCodeOrName;
     if (_.isString(levelCodeOrName)) {

--- a/src/minlog.js
+++ b/src/minlog.js
@@ -47,6 +47,12 @@ export default class MinLog {
     });
   }
 
+  levelIsBeyondGroup(levelCodeOrName, groupCodeOrName) {
+    let levelCode = this.levelToLevelCode(levelCodeOrName);
+    let maxLevelCode = this.maxLevelCodeInGroup(groupCodeOrName);
+    return levelCode > maxLevelCode;
+  }
+
   levelToLevelCode(levelCodeOrName) {
     if (_.isInteger(levelCodeOrName)) {
       let levelCode = levelCodeOrName;

--- a/test/minlog.test.js
+++ b/test/minlog.test.js
@@ -102,4 +102,24 @@ describe('minlog', function() {
       expect(logger.maxLevelCodeInGroup(70)).toBe(79);
     });
   });
+
+  describe('levelIsBeyondGroup', function() {
+    let logger = new MinLog();
+
+    it('should return true for levels beyond the group', function() {
+      expect(logger.levelIsBeyondGroup('debug', 'info')).toBe(true);
+      expect(logger.levelIsBeyondGroup('debug', 60)).toBe(true);
+      expect(logger.levelIsBeyondGroup(70, 'info')).toBe(true);
+    });
+
+    it('should return false for levels below and in the group', function() {
+      expect(logger.levelIsBeyondGroup('info', 'debug')).toBe(false);
+      expect(logger.levelIsBeyondGroup(60, 'debug')).toBe(false);
+      expect(logger.levelIsBeyondGroup('info', 70)).toBe(false);
+
+      expect(logger.levelIsBeyondGroup('info', 'info')).toBe(false);
+      expect(logger.levelIsBeyondGroup(60, 'info')).toBe(false);
+      expect(logger.levelIsBeyondGroup('info', 60)).toBe(false);
+    });
+  });
 });

--- a/test/minlog.test.js
+++ b/test/minlog.test.js
@@ -92,4 +92,14 @@ describe('minlog', function() {
       });
     });
   });
+
+  describe('maxLevelCodeInGroup', function() {
+    let logger = new MinLog();
+
+    it('should return the maximum level up to the next group, not inclusive', function() {
+      expect(logger.maxLevelCodeInGroup(60)).toBe(69);
+      expect(logger.maxLevelCodeInGroup(69)).toBe(69);
+      expect(logger.maxLevelCodeInGroup(70)).toBe(79);
+    });
+  });
 });


### PR DESCRIPTION
to check if an entry should be ignored by a listener

PS: naming is unfortunate, at least levelIsBeyondGroup should maybe be "shouldIgnoreEntry(entryLevel, listenerLevel)" or smth. Happy to go with anything.